### PR TITLE
fix: rendering error on lab2 instructions markdown

### DIFF
--- a/demo2-assets/openshift/prod/pipeline/library-shop.trigger.yaml
+++ b/demo2-assets/openshift/prod/pipeline/library-shop.trigger.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: library-shop-pipelines
     group: rhacademy
-  name: libray-shop
+  name: library-shop
 spec:
   serviceAccountName: pipeline
   bindings:

--- a/demo2-assets/openshift/prod/pipeline/library-shop.triggerbinding.yaml
+++ b/demo2-assets/openshift/prod/pipeline/library-shop.triggerbinding.yaml
@@ -13,4 +13,4 @@ spec:
   - name: git-repo-name
     value: $(body.repository.name)
   - name: git-revision
-    value: $(body.head_commit.id)
+    value: $(body.after)

--- a/demo2-assets/openshift/prod/pipeline/library-shop.triggertemplate.yaml
+++ b/demo2-assets/openshift/prod/pipeline/library-shop.triggertemplate.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: library-shop-pipelines
         group: rhacademy
-      generateName: pipeline-library-shop-
+      generateName: library-shop-trigger-
     spec:
       workspaces:
       - name: shared-workspace

--- a/lab2.md
+++ b/lab2.md
@@ -113,8 +113,7 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
     ./mvnw oc:resource oc:apply
     ~~~
 
-    ~~output
-    ...
+    ~~~output
     [INFO] --- oc:1.15.0:apply (default-cli) @ library-shop ---
     [INFO] oc: OpenShift platform detected
     [INFO] oc: Using OpenShift at https://api.crc.testing:6443/ in namespace null with manifest target/classes/META-INF/jkube/openshift.yml
@@ -142,6 +141,8 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
     library-shop-5cfffb9db8-phlrx   1/1     Running     0          6m23s
     library-shop-s2i-1-build        0/1     Completed   0          21m
     ~~~
+
+    NOTE: Ctrl+C to exit from the watch
 
 9. Check the application is working correctly
 


### PR DESCRIPTION
- bad output markdown tag on lab2 instructions
- add instruction note to close the pods watch
- fix Trigger name typo
- change pattern name for PipelineRun on TriggerTemplate
- change git-revision param extraction on TriggerBinding