### PR TITLE
feat: include lab creation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,68 +4,177 @@
 
 List of fedora packages that need to be installed
 
-```
-java-21-openjdk
-java-21-openjdk-devel
-java-21-openjdk-headless
-java-21-openjdk-javadoc
-java-21-openjdk-src
-podman
-curl
-jq
-```
+    ~~~
+    java-21-openjdk
+    java-21-openjdk-devel
+    java-21-openjdk-headless
+    java-21-openjdk-javadoc
+    java-21-openjdk-src
+    podman
+    podman-compose
+    podman-remote
+    podman-docker
+    curl
+    jq
+    ~~~
 
-## Resources
+Binary dependencies:
+
+    ~~~sh
+    # kubectl and oc
+    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.20.9/openshift-client-linux-4.20.9.tar.gz -o /tmp/oc.tar.gz && sudo tar -C /usr/local/bin -xzf /tmp/oc.tar.gz oc kubectl && sudo chmod +x /usr/local/bin/oc /usr/local/bin/kubectl
+    # tkn
+    curl https://mirror.openshift.com/pub/openshift-v4/amd64/clients/pipelines/latest/tkn-linux-amd64.tar.gz -o /tmp/tkn.tar.gz && sudo tar -C /usr/local/bin -xzf /tmp/tkn.tar.gz tkn && sudo chmod +x /usr/local/bin/tkn
+    # Visual Studio Code
+    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
+    echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\nautorefresh=1\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.repos.d/vscode.repo > /dev/null && sudo dnf install code -y
+    ~~~
+
+## Container Image Resources
 
 Container Images that will be used:
 
-```sh
-docker.io/testcontainers/ryuk:0.12.0
-docker.io/library/postgres:17
-registry.access.redhat.com/ubi9/openjdk-21:1.24
-registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
-registry.access.redhat.com/ubi9/ubi-minimal:9.7
-quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21
-quay.io/quarkus/ubi9-quarkus-micro-image:2.0
-```
+    ~~~sh
+    docker.io/testcontainers/ryuk:0.12.0
+    docker.io/library/postgres:17
+    registry.access.redhat.com/ubi9/openjdk-21:1.24
+    registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
+    registry.access.redhat.com/ubi9/ubi-minimal:9.7
+    quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21
+    quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+    ~~~
 
+## Required Visual Studio Code extensions
 
-## Download artifacts
+    ~~~sh
+    # Java and Quarkus extensions
+    # redhat.vscode-quarkus vscjava.vscode-java-pack redhat.vscode-microprofile redhat.vscode-yaml redhat.vscode-xml
+    code --install-extension vscjava.vscode-java-pack
+    code --install-extension redhat.vscode-quarkus
+    code --install-extension redhat.vscode-microprofile
+    code --install-extension redhat.vscode-yaml
+    code --install-extension redhat.vscode-xml
+    ~~~
+
+## Pre-Download Java and Maven artifacts
 
 List of maven commands that will be used:
 
-```sh
-./mvnw clean
-./mvnw validate compile test package
-./mvnw verify
-```
+    ~~~sh
+    ./mvnw clean
+    ./mvnw validate compile test package
+    ./mvnw verify
+    ~~~
 
-- Interactive commands
+Interactive commands
 
-```sh
-./mvnw quarkus:dev
-./mvnw quarkus:test
-```
+    ~~~sh
+    ./mvnw quarkus:dev
+    ./mvnw quarkus:test
+    ~~~
 
-- Container building
+Container building
 
-```sh
-./mvnw package -Pjib
-./mvnw package -Pdocker
-./mvnw package -Ppodman
-```
+    ~~~sh
+    ./mvnw package -Pjib
+    ./mvnw package -Pdocker
+    ./mvnw package -Ppodman
+    ~~~
 
-- Native binary building
+Native binary building
 
-```sh
-./mvnw package -Dnative -Dquarkus.native.builder-image.pull=never -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman
-./mvnw test-compile failsafe:integration-test -Dnative
-```
+    ~~~sh
+    ./mvnw package -Dnative -Dquarkus.native.builder-image.pull=never -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman
+    ./mvnw test-compile failsafe:integration-test -Dnative
+    ~~~
 
-- Build container with native binary
+Build container with native binary
 
-```sh
-./mvnw verify -DskipTests -Dnative -Pdocker -Dquarkus.container-image.name=library-shop-docker-native -Dquarkus.native.reuse-existing=true
-./mvnw verify -DskipTests -Dnative -Ppodman -Dquarkus.container-image.name=library-shop-docker-native -Dquarkus.native.reuse-existing=true
-./mvnw package -DskipTests -Dnative -Pjib -Dquarkus.container-image.name=library-shop-jib-native -Dquarkus.native.reuse-existing=true
-```
+    ~~~sh
+    ./mvnw verify -DskipTests -Dnative -Pdocker -Dquarkus.container-image.name=library-shop-docker-native -Dquarkus.native.reuse-existing=true
+    ./mvnw verify -DskipTests -Dnative -Ppodman -Dquarkus.container-image.name=library-shop-docker-native -Dquarkus.native.reuse-existing=true
+    ./mvnw package -DskipTests -Dnative -Pjib -Dquarkus.container-image.name=library-shop-jib-native -Dquarkus.native.reuse-existing=true
+    ~~~
+
+    In case of limited resources, there are properties to limit the resources used by the container builder:
+
+    ~~~sh
+    -Dquarkus.native.container-runtime-options="--cpus=4,--memory=6G"
+    ~~~
+
+## Configure lab environment
+
+As the user we are going to use podman as the container runtime, we need to configure the environment variables to use podman.
+
+    ~~~sh
+    systemctl --user enable podman.socket --now
+    cat << __EOF >> ~/.bashrc
+
+    # Lab environment variables
+    DOCKER_HOST=unix:///run/user/${UID}/podman/podman.sock
+    JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+    TESTCONTAINERS_RYUK_DISABLED=false
+
+    export DOCKER_HOST JAVA_HOME TESTCONTAINERS_RYUK_DISABLED
+    __EOF
+    ~~~
+
+## Labs requirements
+
+The labs in this repo were tested in a Fedora 43 system with the following hardware and software versions:
+
+Hardware:
+
+- 4 vCPUs
+- 8 GiB RAM
+- 40 GB HD
+
+## Preparing the system for the labs
+
+1. Create the script that prepares the VM
+
+    ~~~sh
+    cat << EOF > prepare_env.sh
+    #!/bin/bash
+
+    sudo dnf5 group install workstation-product-environment -y
+    sudo systemctl set-default graphical.target
+    sudo useradd student -G wheel
+    echo "student:student" | chpasswd
+    # sudo dnf install -y podman podman-compose virtualbox-guest-additions
+    sudo dnf install -y java-21-openjdk java-21-openjdk-devel java-21-openjdk-headless java-21-openjdk-javadoc java-21-openjdk-src podman podman-compose podman-remote podman-docker curl jq
+    sudo dnf remove java-25-openjdk-headless
+    # kubectl and oc
+    curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.20.9/openshift-client-linux-4.20.9.tar.gz -o /tmp/oc.tar.gz && sudo tar -C /usr/local/bin -xzf /tmp/oc.tar.gz oc && sudo chmod +x /usr/local/bin/oc /usr/local/bin/kubectl
+    curl https://mirror.openshift.com/pub/openshift-v4/amd64/clients/pipelines/latest/tkn-linux-amd64.tar.gz -o /tmp/tkn.tar.gz && sudo tar -C /usr/local/bin -xzf /tmp/tkn.tar.gz tkn && sudo chmod +x /usr/local/bin/tkn
+    # Visual Studio Code
+    sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
+    echo -e "[code]\nname=Visual Studio Code\nbaseurl=https://packages.microsoft.com/yumrepos/vscode\nenabled=1\nautorefresh=1\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" | sudo tee /etc/yum.repos.d/vscode.repo > /dev/null && sudo dnf install code -y
+    # Container images
+    sudo -iu student podman pull docker.io/testcontainers/ryuk:0.12.0
+    sudo -iu student podman pull docker.io/library/postgres:17
+    sudo -iu student podman pull registry.access.redhat.com/ubi9/openjdk-21:1.24
+    sudo -iu student podman pull registry.access.redhat.com/ubi9/openjdk-21-runtime:1.24
+    sudo -iu student podman pull registry.access.redhat.com/ubi9/ubi-minimal:9.7
+    sudo -iu student podman pull quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-21
+    sudo -iu student podman pull quay.io/quarkus/ubi9-quarkus-micro-image:2.0
+    sudo -iu student podman pull docker.io/library/hello-world:latest
+    sudo -iu student podman pull docker.io/library/httpd:2.4
+    # Java and Quarkus extensions
+    # redhat.vscode-quarkus vscjava.vscode-java-pack redhat.vscode-microprofile redhat.vscode-yaml redhat.vscode-xml
+    sudo -iu student code --install-extension vscjava.vscode-java-pack
+    sudo -iu student code --install-extension redhat.vscode-quarkus
+    sudo -iu student code --install-extension redhat.vscode-microprofile
+    sudo -iu student code --install-extension redhat.vscode-yaml
+    sudo -iu student code --install-extension redhat.vscode-xml
+
+    sudo reboot
+
+    EOF
+    ~~~
+
+2. Create the VM
+
+    ~~~sh
+    kcli create vm -i fedora43 -P numcpus=4 -P memory=8192 -P name=rha-2026 -P disks=[40] -P scripts=[prepare_env.sh]
+    ~~~

--- a/lab1.md
+++ b/lab1.md
@@ -305,7 +305,7 @@ In this lab we are going to see how we can use Java with [Quarkus](https://quark
     podman stop library-shop-app
     ~~~
 
-### Build the container image using Quarkus Docker Extension
+### Build the container image using Quarkus Podman Extension
 
 1. In one of the terminals, change into the application directory and run the build command:
 
@@ -328,7 +328,7 @@ In this lab we are going to see how we can use Java with [Quarkus](https://quark
 2. Run the generated container image and check the application runs correctly:
 
     ~~~sh
-    podman run --net rhademo --name library-shop-app --rm -d -e DATABASE_HOST=pg-library-shop -p 8080:8080 rha/library-shop-docker:1.0.0
+    podman run --net rhademo --name library-shop-app --rm -d -e DATABASE_HOST=pg-library-shop -p 8080:8080 rha/library-shop-podman:1.0.0
     ~~~
 
 3. Verify the application runs correctly:
@@ -354,7 +354,7 @@ In this lab we are going to see how we can use Java with [Quarkus](https://quark
     ~~~
 
     ~~~output
-    localhost/rha/library-shop-docker                   1.0.0       5b0dd26b635c  2 minutes ago      406 MB
+    localhost/rha/library-shop-podman                   1.0.0       5b0dd26b635c  2 minutes ago      406 MB
     localhost/rha/library-shop-jib                      1.0.0       b15f3e3b6ab0  5 minutes ago      406 MB
     localhost/rha/library-shop                          1.0.0       5c8c31912a20  35 minutes ago      406 MB
     ~~~
@@ -542,12 +542,12 @@ More information around building a native executable can be found in the [offici
 
     ~~~sh
     cd ~/library-shop
-    ./mvnw verify -Dnative -Ppodman -Dquarkus.container-image.name=library-shop-docker-native -Dquarkus.native.reuse-existing=true
+    ./mvnw verify -Dnative -Ppodman -Dquarkus.container-image.name=library-shop-podman-native -Dquarkus.native.reuse-existing=true
     ~~~
 
     ~~~output
     [INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Starting (local) container image build for jar using podman
-    [INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Executing the following command to build image: 'podman build -f /home/student/library-shop/src/main/docker/Containerfile.native -t rha/library-shop-docker-native:1.0.0 /home/student/library-shop'
+    [INFO] [io.quarkus.container.image.docker.common.deployment.CommonProcessor] Executing the following command to build image: 'podman build -f /home/student/library-shop/src/main/docker/Containerfile.native -t rha/library-shop-podman-native:1.0.0 /home/student/library-shop'
     [INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 3185ms
 
     ~~~
@@ -581,9 +581,9 @@ During this lab we have built several container images, we will see how the one 
 
     ~~~output
     localhost/rha/library-shop-jib-native               1.0.0           346c620e26de  42 seconds ago  128 MB
-    localhost/rha/library-shop-docker-native            1.0.0           1354f4b0a7f0  7 minutes ago   203 MB
+    localhost/rha/library-shop-podman-native            1.0.0           1354f4b0a7f0  7 minutes ago   203 MB
     localhost/rha/library-shop-native                   1.0.0           1354f4b0a7f0  7 minutes ago   203 MB
-    localhost/rha/library-shop-docker                   1.0.0           8041fd1c34a1  32 minutes ago  421 MB
+    localhost/rha/library-shop-podman                   1.0.0           8041fd1c34a1  32 minutes ago  421 MB
     localhost/rha/library-shop-jib                      1.0.0           da33481d0656  36 minutes ago  422 MB
     localhost/rha/library-shop                          1.0.0           a88470feeb9f  56 minutes ago  421 MB
     ~~~


### PR DESCRIPTION
The instructions to create a virtual machine for running the workshop preloading the requisistes.


Also switch the lab1 instructions to use the quarkus podman extension instead of quarkus docker extension