### PR TITLE
feat: update lab2 postgresql image to 16-el10

### DIFF
--- a/demo2-assets/openshift/dev/database.deployment.yaml
+++ b/demo2-assets/openshift/dev/database.deployment.yaml
@@ -41,13 +41,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"postgresql:15-el9","namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"postgresql\")].image"}]'
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"postgresql:16-el10","namespace":"openshift"},"fieldPath":"spec.template.spec.containers[?(@.name==\"postgresql\")].image"}]'
   labels:
     app.kubernetes.io/part-of: rhacademy
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: library-shop-db
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: "15-el9"
+    app.kubernetes.io/version: "16-el10"
     app: library-shop-db
   name: library-db
 spec:
@@ -83,7 +83,7 @@ spec:
                 secretKeyRef:
                   key: DATABASE_NAME
                   name: library-db
-          image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql@sha256:8910bd59fcf917fc54f47342939ca3f828560f1881245ed3777ace21e0367963
+          image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql:16-el10
           imagePullPolicy: IfNotPresent
           lifecycle:
             postStart:

--- a/demo2-assets/openshift/dev/postgresql-16-el10.imagestreamtag.yaml
+++ b/demo2-assets/openshift/dev/postgresql-16-el10.imagestreamtag.yaml
@@ -1,0 +1,26 @@
+---
+# oc tag -n openshift registry.redhat.io/rhel10/postgresql-16@sha256:ca3241a3fa3a15a34b8b0f0ba60c8b7d8b706420ef745bc55a641d93e9a3b6a5 postgresql:16-el10
+kind: ImageStreamTag
+apiVersion: image.openshift.io/v1
+metadata:
+  name: postgresql:16-el10
+  namespace: openshift
+  creationTimestamp: null
+tag:
+  name: 16-el10
+  annotations: null
+  from:
+    kind: DockerImage
+    name: registry.redhat.io/rhel10/postgresql-16@sha256:ca3241a3fa3a15a34b8b0f0ba60c8b7d8b706420ef745bc55a641d93e9a3b6a5
+  generation: 0
+  importPolicy:
+    importMode: Legacy
+  referencePolicy:
+    type: Source
+generation: 0
+lookupPolicy:
+  local: false
+image:
+  metadata:
+    creationTimestamp: null
+  dockerImageMetadata: null

--- a/lab2.md
+++ b/lab2.md
@@ -4,7 +4,7 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
 
 ## Lab 1 - Deploy *as a Developer* the Quarkus application
 
-1. Connect to the Fedora 41 system.
+1. Connect to the Fedora 43 system.
 
 2. You should already have the `Visual Studio Code` application opened, if not, go ahead an open it.
 
@@ -16,7 +16,7 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
 
     ~~~sh
     cd ~/library-shop/
-    ./mvnw package
+    ./mvnw package -Dnative -Dquarkus.native.builder-image.pull=never -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman -Dquarkus.native.reuse-existing=true
     ~~~
 
 6. Login into OpenShift:
@@ -87,7 +87,7 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
 9. Launch the build for the application in OpenShift:
 
     ~~~sh
-    ./mvnw oc:build
+    ./mvnw oc:build -Djkube.generator.from=quay.io/quarkus/ubi9-quarkus-native-binary-s2i:2.0
     ~~~
 
     ~~~output
@@ -119,6 +119,15 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
         ~~~output
         NAME                       READY   STATUS      RESTARTS   AGE
         library-shop-s2i-1-build   0/1     Completed   0          11m
+        ~~~
+
+        ~~~sh
+        oc get is library-shop
+        ~~~
+
+        ~~~output
+        NAME           IMAGE REPOSITORY                                                              TAGS    UPDATED
+        library-shop   image-registry.openshift-image-registry.svc:5000/student1--dev/library-shop   1.0.0   10 minutes ago
         ~~~
 
 10. Deploy the application:
@@ -181,7 +190,7 @@ In this lab we are going to see how we can use Java with Quarkus to build and ru
         ~~~
 
         ~~~output
-        ehlo from PostgreSQL 15.3 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-18), 64-bit
+        ehlo from PostgreSQL 16.11 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 14.3.1 20250617 (Red Hat 14.3.1-2), 64-bit
         ~~~
 
         ~~~sh


### PR DESCRIPTION
- Update Postgresql image for the lab 3 Part1 to Postgresql 16 (based on RHEL 10) 
- Update lab for the latest postgresql
- Fix base image for quarkus generator when native image is present